### PR TITLE
Fix logic for R.

### DIFF
--- a/tmpfiles
+++ b/tmpfiles
@@ -310,7 +310,7 @@ _R() {
 	[ $REMOVE -gt 0 ] || return 0
 
 	for path in ${paths}; do
-		[ -d "$path" ] && dryrun_or_real rm -rf --one-file-system "$path"
+		! [ -d "$path" ] || dryrun_or_real rm -rf --one-file-system "$path"
 	done
 }
 


### PR DESCRIPTION
It should not be an error ($? != 0) to apply R to a nonexistent path.
Without this fix, tmpfiles refuses to start when systemd-233 is installed,
because this provides config files containing lines like
R /tmp/systemd-private-*  0 0 0